### PR TITLE
Add a vanilla Linux VM based on CentOS 7

### DIFF
--- a/assets/centos-ks.cfg
+++ b/assets/centos-ks.cfg
@@ -28,7 +28,7 @@ user --name=travis --plaintext --password travis --groups=wheel
 
 # install a current version of Ansible from EPEL
 yum update -y
-yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+yum install -y epel-release
 yum install -y ansible
 
 # sudo

--- a/assets/centos-ks.cfg
+++ b/assets/centos-ks.cfg
@@ -31,6 +31,9 @@ yum update -y
 yum install -y epel-release
 yum install -y ansible
 
+# install perl so that VMware customization actually works
+yum install -y perl
+
 # sudo
 yum install -y sudo
 sed -i "s/^%wheel.*$/%wheel	ALL=(ALL)	NOPASSWD: ALL/" /etc/sudoers

--- a/assets/centos-ks.cfg
+++ b/assets/centos-ks.cfg
@@ -25,7 +25,10 @@ user --name=travis --plaintext --password travis --groups=wheel
 %end
 
 %post
+
+# install a current version of Ansible from EPEL
 yum update -y
+yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
 yum install -y ansible
 
 # sudo

--- a/assets/centos-ks.cfg
+++ b/assets/centos-ks.cfg
@@ -1,0 +1,35 @@
+install
+cdrom
+lang en_US.UTF-8
+keyboard us
+unsupported_hardware
+network --bootproto=dhcp
+firewall --disabled
+selinux --permissive
+timezone UTC
+bootloader --location=mbr
+text
+skipx
+zerombr
+clearpart --all --initlabel
+autopart
+auth --enableshadow --passalgo=sha512 --kickstart
+firstboot --disabled
+eula --agreed
+services --enabled=NetworkManager,sshd
+reboot
+user --name=travis --plaintext --password travis --groups=wheel
+
+%packages --ignoremissing --excludedocs
+@Core
+ansible
+%end
+
+%post
+
+# sudo
+yum install -y sudo
+sed -i "s/^%wheel.*$/%wheel	ALL=(ALL)	NOPASSWD: ALL/" /etc/sudoers
+
+yum clean all
+%end

--- a/assets/centos-ks.cfg
+++ b/assets/centos-ks.cfg
@@ -22,10 +22,11 @@ user --name=travis --plaintext --password travis --groups=wheel
 
 %packages --ignoremissing --excludedocs
 @Core
-ansible
 %end
 
 %post
+yum update -y
+yum install -y ansible
 
 # sudo
 yum install -y sudo

--- a/linux_playbooks/roles/cleanup/tasks/main.yml
+++ b/linux_playbooks/roles/cleanup/tasks/main.yml
@@ -2,6 +2,5 @@
   user:
     name: travis
     password_lock: true
-    expires: 0 # Expired at the Unix epoch
     shell: /usr/sbin/nologin
   become: true

--- a/linux_playbooks/roles/logging/tasks/main.yml
+++ b/linux_playbooks/roles/logging/tasks/main.yml
@@ -1,7 +1,14 @@
-- name: install rsyslog-gnutls
+- name: install rsyslog-gnutls (apt)
   apt:
     name: rsyslog-gnutls
   become: true
+  when: ansible_facts['pkg_mgr'] == "apt"
+
+- name: install rsyslog-gnutls (yum)
+  yum:
+    name: rsyslog-gnutls
+  become: true
+  when: ansible_facts['pkg_mgr'] == "yum"
 
 - name: install papertrail certificate bundle
   get_url:

--- a/linux_playbooks/roles/ssh/defaults/main.yml
+++ b/linux_playbooks/roles/ssh/defaults/main.yml
@@ -1,0 +1,1 @@
+sftp_server_path: /usr/lib/openssh/sftp-server

--- a/linux_playbooks/roles/ssh/tasks/main.yml
+++ b/linux_playbooks/roles/ssh/tasks/main.yml
@@ -21,8 +21,8 @@
   become: true
 
 - name: copy sshd configuration
-  copy:
-    src: etc_ssh_sshd_config
+  template:
+    src: etc_ssh_sshd_config.j2
     dest: /etc/ssh/sshd_config
     owner: root
     group: root

--- a/linux_playbooks/roles/ssh/templates/etc_ssh_sshd_config.j2
+++ b/linux_playbooks/roles/ssh/templates/etc_ssh_sshd_config.j2
@@ -22,7 +22,7 @@ PrintMotd no
 PrintLastLog yes
 TCPKeepAlive yes
 AcceptEnv LANG LC_*
-Subsystem sftp /usr/lib/openssh/sftp-server
+Subsystem sftp {{ sftp_server_path }}
 UsePAM yes
 UseDNS no
 AllowAgentForwarding yes

--- a/linux_playbooks/roles/users/defaults/main.yml
+++ b/linux_playbooks/roles/users/defaults/main.yml
@@ -1,0 +1,3 @@
+user_groups:
+  - sudo
+  - ssh-user

--- a/linux_playbooks/roles/users/tasks/main.yml
+++ b/linux_playbooks/roles/users/tasks/main.yml
@@ -1,9 +1,7 @@
 - name: Create users
   user:
     name: "{{ item.key }}"
-    groups:
-    - sudo
-    - ssh-user
+    groups: "{{ user_groups }}"
     shell: /bin/bash
     home: /home/{{ item.key }}
   loop: "{{ users|dict2items }}"

--- a/linux_playbooks/roles/yum/tasks/main.yml
+++ b/linux_playbooks/roles/yum/tasks/main.yml
@@ -1,0 +1,5 @@
+- name: update yum packages
+  yum:
+    name: '*'
+    state: latest
+  become: true

--- a/linux_playbooks/vanilla_centos.yml
+++ b/linux_playbooks/vanilla_centos.yml
@@ -1,0 +1,15 @@
+---
+- hosts: localhost
+  roles:
+  - yum
+  - ssh
+  - users
+  - logging
+  - cleanup
+  vars_files:
+  - secrets.yml
+  vars:
+    user_groups:
+      - wheel
+      - ssh-user
+    sftp_server_path: /usr/libexec/openssh/sftp-server

--- a/templates/centos7.yml
+++ b/templates/centos7.yml
@@ -52,7 +52,7 @@ provisioners:
   playbook_file: linux_playbooks/vanilla_centos.yml
 - type: shell
   inline:
-  - "sudo yum list installed > /tmp/yum_packages"
+  - "yum list installed > /tmp/yum_packages"
 - type: file
   direction: download
   source: /tmp/yum_packages

--- a/templates/centos7.yml
+++ b/templates/centos7.yml
@@ -1,0 +1,65 @@
+---
+description: Mac infra template for Linux VMs using CentOS 7
+variables:
+  vm_name: travis-ci-centos7-internal-vanilla-{{ timestamp }}
+  records_path: records/centos7
+
+  ssh_password: "{{ env `TRAVIS_PACKER_SSH_PASSWORD` }}"
+  vcenter_server: "{{ env `VCENTER_SERVER` }}"
+  vcenter_user: "{{ env `VCENTER_USER` }}"
+  vcenter_password: "{{ env `VCENTER_PASSWORD` }}"
+  vcenter_insecure: "{{ env `VCENTER_INSECURE` }}"
+builders:
+- type: vsphere-iso
+  name: vsphere
+  ssh_timeout: 5m
+  ssh_port: 22
+  ssh_username: travis
+  ssh_password: "{{ user `ssh_password` }}"
+  vcenter_server: "{{ user `vcenter_server` }}"
+  username: "{{ user `vcenter_user` }}"
+  password: "{{ user `vcenter_password` }}"
+  insecure_connection: "{{ user `vcenter_insecure` }}"
+  datacenter: "pod-1"
+  cluster: MacPro_Pod_1
+  host: 10.88.242.100
+  datastore: "DataCore1_1"
+  folder: "Vanilla VMs"
+  vm_name: "{{ user `vm_name` }}"
+  CPUs: 2
+  CPU_reservation: 0
+  CPU_limit: 99999
+  RAM: 4096
+  RAM_reservation: 0
+  disk_size: 32768
+  disk_controller_type: pvscsi
+  guest_os_type: centos7_64Guest
+  shutdown_timeout: 5m
+  shutdown_command: sudo poweroff
+  create_snapshot: true
+  convert_to_template: false
+  network_card: vmxnet3
+  network: Internal
+  iso_paths:
+  - "[ISO (1)] CENTOS/CentOS-7-x86_64-DVD-1708.iso"
+  floppy_files:
+  - assets/centos-ks.cfg
+  boot_command:
+  - "<tab> text ks=hd:fd0:/centos-ks.cfg<enter><wait>"
+provisioners:
+- type: ansible-local
+  playbook_dir: linux_playbooks
+  playbook_file: linux_playbooks/vanilla_centos.yml
+- type: shell
+  inline:
+  - "sudo yum list installed > /tmp/yum_packages"
+- type: file
+  direction: download
+  source: /tmp/yum_packages
+  destination: "{{ user `records_path` }}/yum_packages"
+post-processors:
+- type: shell-local
+  environment_vars:
+  - IMAGE_NAME={{ user `vm_name` }}
+  inline:
+  - bin/finalize-linux-image "$IMAGE_NAME"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

Our Xenial images, which we use for new Linux VMs, particularly those running Kubernetes, can no longer be provisioned since we upgraded to vCenter/ESXi 6.7. They fail in customization. Trusty VMs work fine, but are too old to run Kubernetes with kubeadm.

## What approach did you choose and why?

I tried for a while to figure out what the issue was with Xenial. I believe it's some kind of bad interaction with the open-vm-tools on it and the new VMware versions we're using. I've found at least one other person online who had similar issues, but they did not get any responses to help find a solution. After trying numerous workarounds and ways of isolating, I gave up and tried using CentOS instead of Ubuntu.

CentOS 7 is in general running newer tools than Xenial, and that includes the open-vm-tools. I don't know if the version is the only factor, but the end result is that an image running CentOS does handle VM customization successfully!

## How can you test this?

I built the image, then provisioned a VM cloned from it using Terraform.

## What feedback would you like, if any?

Any.