### PR TITLE
Create a CentOS-based image with Kubernetes pre-installed

### DIFF
--- a/linux_playbooks/kubernetes_centos.yml
+++ b/linux_playbooks/kubernetes_centos.yml
@@ -1,0 +1,17 @@
+---
+- hosts: localhost
+  roles:
+  - yum
+  - ssh
+  - users
+  - logging
+  - docker
+  - kubernetes
+  - cleanup
+  vars_files:
+  - secrets.yml
+  vars:
+    user_groups:
+      - wheel
+      - ssh-user
+    sftp_server_path: /usr/libexec/openssh/sftp-server

--- a/linux_playbooks/roles/docker/tasks/main.yml
+++ b/linux_playbooks/roles/docker/tasks/main.yml
@@ -1,0 +1,23 @@
+- name: install docker tools (yum)
+  yum:
+    name:
+    - yum-utils
+    - device-mapper-persistent-data
+    - lvm2
+  become: true
+
+- name: add docker repository (yum)
+  command: yum-config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
+  become: true
+
+- name: install docker (yum)
+  yum:
+    name:
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+
+- name: start docker service
+  systemd:
+    name: docker
+    state: started

--- a/linux_playbooks/roles/docker/tasks/main.yml
+++ b/linux_playbooks/roles/docker/tasks/main.yml
@@ -16,8 +16,10 @@
       - docker-ce
       - docker-ce-cli
       - containerd.io
+  become: true
 
 - name: start docker service
   systemd:
     name: docker
     state: started
+  become: true

--- a/linux_playbooks/roles/docker/tasks/main.yml
+++ b/linux_playbooks/roles/docker/tasks/main.yml
@@ -21,5 +21,5 @@
 - name: start docker service
   systemd:
     name: docker
-    state: started
+    enabled: true
   become: true

--- a/linux_playbooks/roles/kubernetes/tasks/main.yml
+++ b/linux_playbooks/roles/kubernetes/tasks/main.yml
@@ -21,6 +21,11 @@
     fstype: swap
     state: absent
 
+# When used for master VMs, we need this tool
+- name: install jq
+  yum:
+    name: jq
+
 - name: add kubernetes repository (yum)
   yum_repository:
     name: kubernetes

--- a/linux_playbooks/roles/kubernetes/tasks/main.yml
+++ b/linux_playbooks/roles/kubernetes/tasks/main.yml
@@ -1,0 +1,44 @@
+- name: enable br_netfilter
+  modprobe:
+    name: br_netfilter
+  become: true
+
+- name: fix iptables (ipv4)
+  sysctl:
+    name: net.bridge.bridge-nf-call-ip6tables
+    value: 1
+  become: true
+
+- name: fix iptables (ipv6)
+  sysctl:
+    name: net.bridge.bridge-nf-call-iptables
+    value: 1
+  become: true
+
+- name: add kubernetes repository (yum)
+  yum_repository:
+    name: kubernetes
+    description: Kubernetes
+    baseurl: https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
+    gpgcheck: yes
+    repo_gpgcheck: yes
+    gpgkey:
+    - https://packages.cloud.google.com/yum/doc/yum-key.gpg
+    - https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
+    exclude: kube*
+  become: true
+
+- name: install kubernetes tools (yum)
+  yum:
+    name:
+    - kubelet
+    - kubeadm
+    - kubectl
+    disable_excludes: kubernetes
+  become: true
+
+- name: enable kubelet service
+  systemd:
+    name: kubelet
+    enabled: true
+  become: true

--- a/linux_playbooks/roles/kubernetes/tasks/main.yml
+++ b/linux_playbooks/roles/kubernetes/tasks/main.yml
@@ -15,6 +15,11 @@
     value: 1
   become: true
 
+- name: disable swap mount
+  mount:
+    fstype: swap
+    state: absent
+
 - name: add kubernetes repository (yum)
   yum_repository:
     name: kubernetes

--- a/linux_playbooks/roles/kubernetes/tasks/main.yml
+++ b/linux_playbooks/roles/kubernetes/tasks/main.yml
@@ -20,11 +20,13 @@
     path: swap
     fstype: swap
     state: absent
+  become: true
 
 # When used for master VMs, we need this tool
 - name: install jq
   yum:
     name: jq
+  become: true
 
 - name: add kubernetes repository (yum)
   yum_repository:

--- a/linux_playbooks/roles/kubernetes/tasks/main.yml
+++ b/linux_playbooks/roles/kubernetes/tasks/main.yml
@@ -17,6 +17,7 @@
 
 - name: disable swap mount
   mount:
+    path: swap
     fstype: swap
     state: absent
 

--- a/templates/centos7-kubernetes.yml
+++ b/templates/centos7-kubernetes.yml
@@ -1,0 +1,65 @@
+---
+description: Mac infra image for running Kubernetes on CentOS 7
+variables:
+  vm_name: travis-ci-centos7-internal-kubernetes-{{ timestamp }}
+  records_path: records/centos7-kubernetes
+
+  ssh_password: "{{ env `TRAVIS_PACKER_SSH_PASSWORD` }}"
+  vcenter_server: "{{ env `VCENTER_SERVER` }}"
+  vcenter_user: "{{ env `VCENTER_USER` }}"
+  vcenter_password: "{{ env `VCENTER_PASSWORD` }}"
+  vcenter_insecure: "{{ env `VCENTER_INSECURE` }}"
+builders:
+- type: vsphere-iso
+  name: vsphere
+  ssh_timeout: 5m
+  ssh_port: 22
+  ssh_username: travis
+  ssh_password: "{{ user `ssh_password` }}"
+  vcenter_server: "{{ user `vcenter_server` }}"
+  username: "{{ user `vcenter_user` }}"
+  password: "{{ user `vcenter_password` }}"
+  insecure_connection: "{{ user `vcenter_insecure` }}"
+  datacenter: "pod-1"
+  cluster: MacPro_Pod_1
+  host: 10.88.242.100
+  datastore: "DataCore1_1"
+  folder: "Vanilla VMs"
+  vm_name: "{{ user `vm_name` }}"
+  CPUs: 2
+  CPU_reservation: 0
+  CPU_limit: 99999
+  RAM: 4096
+  RAM_reservation: 0
+  disk_size: 32768
+  disk_controller_type: pvscsi
+  guest_os_type: centos7_64Guest
+  shutdown_timeout: 5m
+  shutdown_command: sudo poweroff
+  create_snapshot: true
+  convert_to_template: false
+  network_card: vmxnet3
+  network: Internal
+  iso_paths:
+  - "[ISO (1)] CENTOS/CentOS-7-x86_64-DVD-1708.iso"
+  floppy_files:
+  - assets/centos-ks.cfg
+  boot_command:
+  - "<tab> text ks=hd:fd0:/centos-ks.cfg<enter><wait>"
+provisioners:
+- type: ansible-local
+  playbook_dir: linux_playbooks
+  playbook_file: linux_playbooks/kubernetes_centos.yml
+- type: shell
+  inline:
+  - "yum list installed > /tmp/yum_packages"
+- type: file
+  direction: download
+  source: /tmp/yum_packages
+  destination: "{{ user `records_path` }}/yum_packages"
+post-processors:
+- type: shell-local
+  environment_vars:
+  - IMAGE_NAME={{ user `vm_name` }}
+  inline:
+  - bin/finalize-linux-image "$IMAGE_NAME"


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

- It would be nice to have as much image configuration as possible be done in Ansible (instead of bash scripts)
- It would be nice to be able to do as little image customization as possible in Terraform when deploying images for a Kubernetes cluster

## What approach did you choose and why?

Create another image template called `centos7-kubernetes`. It runs the same roles as the `centos7` image, as well as new ones for Docker and Kubernetes. `kubeadm` is installed and ready, so the only thing that should be needed in Terraform to set up a basic Kubernetes cluster is to choose whether the machine will be a master or a node and run the appropriate `kubeadm` command.

I had wanted to build this by cloning the `centos7` vanilla image and then just applying the additional roles, but the `cleanup` role makes it difficult for our Packer build process to SSH into such a machine. So for now at least, it installs from ISO and just reuses many of the files for the vanilla image.

## How can you test this?

I just deployed the `cluster-staging` nodes in MacStadium using this image.

## What feedback would you like, if any?

Any.