### PR TITLE
remove sudo key since it's been deprecated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: true
 language: ruby
 before_script:
 - curl -L https://releases.hashicorp.com/packer/1.2.5/packer_1.2.5_linux_amd64.zip -o /tmp/packer.zip


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?
Remove un-needed sudo key - Travis CI uses a single linux infrastructure https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration

## How can you test this?

Does the build continue green?