### PR TITLE
Install freeze script to support instant clone

### DIFF
--- a/playbooks/roles/travis/files/freeze.sh
+++ b/playbooks/roles/travis/files/freeze.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+cat <<EOF | sudo tee /Library/Application\ Support/VMware\ Tools/tools.conf
+[guestinfo]
+poll-interval = 5
+EOF
+sudo killall vmware-tools-daemon
+
+echo "Disabling networking..."
+sudo kextunload /System/Library/Extensions/IONetworkingFamily.kext/Contents/PlugIns/Intel82574L.kext
+sleep 2
+
+echo "Freezing VM..."
+sleep 1
+sudo /Library/Application\ Support/VMware\ Tools/vmware-tools-daemon --cmd="instantclone.freeze"
+
+echo "Reenabling networking..."
+sudo kextload /System/Library/Extensions/IONetworkingFamily.kext/Contents/PlugIns/Intel82574L.kext

--- a/playbooks/roles/travis/tasks/instant_clone.yml
+++ b/playbooks/roles/travis/tasks/instant_clone.yml
@@ -1,0 +1,5 @@
+- name: Install freeze script
+  copy:
+    src: freeze.sh
+    dest: /Users/travis/freeze.sh
+    mode: 0755

--- a/playbooks/roles/travis/tasks/main.yml
+++ b/playbooks/roles/travis/tasks/main.yml
@@ -3,3 +3,6 @@
 
 - name: Create system-info report
   import_tasks: system_info.yml
+
+- name: Prepare for instant clone
+  import_tasks: instant_clone.yml


### PR DESCRIPTION
## What is the problem that this PR is trying to fix?

To do instant clones, we need to freeze the VMs from within. We also need to take measures to ensure that the networking stack resets afterwards and picks up a new MAC address.

## What approach did you choose and why?

Install a `~/freeze.sh` script into the VMs we build, which we can then login and run to freeze a machine after we've built it. There may be ways to automate the freezing, but it's complex enough that I don't want to tackle it yet.

## How can you test this?

We build an image and try to freeze it! I've been using this script manually in testing instant clone, so I don't expect issues with that.

## What feedback would you like, if any?

Any.